### PR TITLE
StatefulSet Example

### DIFF
--- a/example/StatefulSet/README.md
+++ b/example/StatefulSet/README.md
@@ -1,0 +1,82 @@
+# MongoDB on Kubernetes with Stateful Sets
+
+With the release of [Stateful Sets](http://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/) and custom [Storage Classes](http://kubernetes.io/docs/user-guide/persistent-volumes/#storageclasses), Kubernetes can automate all of the underlying infra required to run a MongoDB Replica Sets
+
+*Note:* Stateful Sets are beta. **This requires Kubernetes 1.5.1**
+
+## Before You Start
+
+- Have a Kubernetes Cluster created with at least version 1.5.1
+- Have admin access to the cluster
+
+## Creating the Storage Class
+
+The storage class will create the [Volumes](http://kubernetes.io/docs/user-guide/persistent-volumes) backing the MongoDB Replica Sets.
+
+You can create Storage Classes with different provisioners depending on your Kubernetes environment. There are provisioners for [Google Cloud](http://kubernetes.io/docs/user-guide/persistent-volumes/#gce), [AWS](http://kubernetes.io/docs/user-guide/persistent-volumes/#aws), [Azure](http://kubernetes.io/docs/user-guide/persistent-volumes/#azure-disk), [GlusterFS](http://kubernetes.io/docs/user-guide/persistent-volumes/#glusterfs), [OpenStack Cinder](http://kubernetes.io/docs/user-guide/persistent-volumes/#openstack-cinder), [vSphere](http://kubernetes.io/docs/user-guide/persistent-volumes/#vsphere), [Ceph RBD](http://kubernetes.io/docs/user-guide/persistent-volumes/#ceph-rbd), and [Quobyte](http://kubernetes.io/docs/user-guide/persistent-volumes/#quobyte). Pick the right one for your deployment.
+
+The [example YAML](googlecloud_ssd.yaml) uses a Google Cloud SSD Persistent Disk, and has the name "ssd"
+
+Create the Storage Class with the `kubectl` tool. Replace `googlecloud_ssd.yaml` with your own configuration file if you are not using Google Cloud:
+
+```
+kubectl apply -f googlecloud_ssd.yaml
+```
+
+Verify that the Storage Class is created
+
+```
+$ kubectl get storageclass   
+NAME      TYPE
+ssd       kubernetes.io/gce-pd 
+```
+
+## Creating the Stateful Set
+
+The [example YAML](mongo-statefulset.yaml) creates a [Headless Service](http://kubernetes.io/docs/user-guide/services/#headless-services) and a [Stateful Set](http://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/). It uses the Storage Class created in the previous step, and provisions a 100Gi volume per replica. Modify these values as you see fit.
+
+```
+kubectl apply -f mongo-statefulset.yaml
+```
+
+Verify that the Stateful Set is created
+```
+$ kubectl get statefulset
+NAME      DESIRED   CURRENT   AGE
+mongo     3         0         12m
+```
+The Stateful Set controller will spin up each replica one at a time. Eventually, all three will be created.
+
+```
+$ kubectl get statefulset
+NAME      DESIRED   CURRENT   AGE
+mongo     3         3         12m
+```
+
+You can also verify that the Volumes were created as well.
+
+```
+$ kubectl get pvc         
+NAME                               STATUS    VOLUME                                     CAPACITY   ACCESSMODES   AGE
+mongo-persistent-storage-mongo-0   Bound     pvc-af87f9d5-d3ab-11e6-8cf2-42010af0018d   100Gi      RWO           12m
+mongo-persistent-storage-mongo-1   Bound     pvc-af8cef48-d3ab-11e6-8cf2-42010af0018d   100Gi      RWO           12m
+mongo-persistent-storage-mongo-2   Bound     pvc-af8f1d24-d3ab-11e6-8cf2-42010af0018d   100Gi      RWO           12m
+```
+
+## Connecting to the MongoDB Replica Set
+
+Each MongoDB Replica Set will have its own DNS address. This will take the format `<pod-name>.<service-name>`.
+
+For our example, the DNS addresses to use will be:
+
+```
+mongo-0.mongo
+mongo-1.mongo
+mongo-2.mongo
+```
+
+Put this in your connection url. For example:
+
+```
+mongodb://mongo-0.mongo,mongo-1.mongo,mongo-2.mongo:27017/dbname_?'
+```

--- a/example/StatefulSet/googlecloud_ssd.yaml
+++ b/example/StatefulSet/googlecloud_ssd.yaml
@@ -1,0 +1,19 @@
+#	Copyright 2017, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: ssd
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd

--- a/example/StatefulSet/mongo-statefulset.yaml
+++ b/example/StatefulSet/mongo-statefulset.yaml
@@ -1,0 +1,70 @@
+#	Copyright 2016, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongo
+  labels:
+    name: mongo
+spec:
+  ports:
+  - port: 27017
+    targetPort: 27017
+  clusterIP: None
+  selector:
+    role: mongo
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: mongo
+spec:
+  serviceName: "mongo"
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        role: mongo
+        environment: test
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+        - name: mongo
+          image: mongo
+          command:
+            - mongod
+            - "--replSet"
+            - rs0
+            - "--smallfiles"
+            - "--noprealloc"
+          ports:
+            - containerPort: 27017
+          volumeMounts:
+            - name: mongo-persistent-storage
+              mountPath: /data/db
+        - name: mongo-sidecar
+          image: leportlabs/mongo-k8s-sidecar
+          env:
+            - name: MONGO_SIDECAR_POD_LABELS
+              value: "role=mongo,environment=test"
+  volumeClaimTemplates:
+  - metadata:
+      name: mongo-persistent-storage
+      annotations:
+        volume.beta.kubernetes.io/storage-class: "ssd"
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 100Gi

--- a/example/StatefulSet/mongo-statefulset.yaml
+++ b/example/StatefulSet/mongo-statefulset.yaml
@@ -54,7 +54,7 @@ spec:
             - name: mongo-persistent-storage
               mountPath: /data/db
         - name: mongo-sidecar
-          image: leportlabs/mongo-k8s-sidecar
+          image: cvallance/mongo-k8s-sidecar
           env:
             - name: MONGO_SIDECAR_POD_LABELS
               value: "role=mongo,environment=test"

--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -191,16 +191,14 @@ var notInReplicaSet = function(db, pods, done) {
 };
 
 var invalidReplicaSet = function(db, pods, done) {
-  // The replica set has become invalid, probably due to catastrophic errors like all nodes going down
-  // this will force elect a new primary and re-initialize the replica set. There is a small chance for data loss here
+  // The replica set config has become invalid, probably due to catastrophic errors like all nodes going down
+  // this will force re-initialize the replica set on this node. There is a small chance for data loss here
   // because it is forcing a reconfigure, but chances are recovering from the invalid state is more important
-  if(podElection){
-    console.log("Invalid set, elected to primary")
-    var addrToAdd = addrToAddLoop(pods, []);
-    mongo.addNewReplSetMembers(db, addrToAdd, [], true, function(err) {
-      finish(err, db);
-    });
-  }
+  console.log("Invalid set, re-initializing")
+  var addrToAdd = addrToAddLoop(pods, []);
+  mongo.addNewReplSetMembers(db, addrToAdd, [], true, function(err) {
+    finish(err, db);
+  });
 }
 
 var podElection = function(pods) {

--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -197,7 +197,7 @@ var invalidReplicaSet = function(db, pods, done) {
   console.log("Invalid set, re-initializing")
   var addrToAdd = addrToAddLoop(pods, []);
   mongo.addNewReplSetMembers(db, addrToAdd, [], true, function(err) {
-    finish(err, db);
+    done(err, db);
   });
 }
 


### PR DESCRIPTION
As mentioned in Issue #14, here is the PR for Stateful Sets.

I've tested this with Google Container Engine, and it seems to work great.

With this, the examples folder can be cleaned up significantly as there is no longer a need for multiple provisioning methods. EmptyDir should also work if you remove the PVC, but it somewhat defeats the purpose of a Stateful Set.

It would be great if we can get more provisioner YAMLs as well (AWS, Azure, Ceph, Cinder, etc). I'm happy to add in more but am hesitant to do so without testing.  