### PR TITLE
Restrict the sidecar to a namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ There you will also find some helper scripts to test out creating the replica se
 
 ### Settings
 
-- KUBE_NAMESPACE
-  Required: NO
+- KUBE_NAMESPACE  
+  Required: NO  
   The namespace to look up pods in. Not setting it will search for pods in all namespaces.
 - MONGO_SIDECAR_POD_LABELS  
   Required: YES  

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ There you will also find some helper scripts to test out creating the replica se
 
 ### Settings
 
+- KUBE_NAMESPACE
+  Required: NO
+  The namespace to look up pods in. Not setting it will search for pods in all namespaces.
 - MONGO_SIDECAR_POD_LABELS  
   Required: YES  
   This should be a be a comma separated list of key values the same as the podTemplate labels. See above for example.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "ip": "^0.3.2",
     "moment": "^2.10.2",
     "mongodb": "^2.0.28",
-    "node-kubernetes-client": "^0.1.9"
+    "node-kubernetes-client": "^0.2.2"
   }
 }

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -24,6 +24,7 @@ var getKubernetesROServiceAddress = function() {
 };
 
 module.exports = {
+  namespace: process.env.KUBE_NAMESPACE,
   loopSleepSeconds: process.env.MONGO_SIDECAR_SLEEP_SECONDS || 5,
   unhealthySeconds: process.env.MONGO_SIDECAR_UNHEALTHY_SECONDS || 15,
   env: process.env.NODE_ENV || 'local',

--- a/src/lib/k8s.js
+++ b/src/lib/k8s.js
@@ -8,6 +8,7 @@ var readToken = fs.readFileSync('/var/run/secrets/kubernetes.io/serviceaccount/t
 
 var client = new Client({
   host: config.kubernetesROServiceAddress,
+  namespace: config.namespace, 
   protocol: 'https',
   version: 'v1',
   token: readToken


### PR DESCRIPTION
Issue:
Running mongos in multiple namespaces pick each other up in the mongo replica set.

Fix:
Update the kube client to pass a namespace.