### PR TITLE
Adds support for stable network IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,23 +56,23 @@ If you want to use the StatefulSets' stable network IDs, you have to make sure t
 environmental variable. Then the MongoDB replica set node names could look like this:
 ```
 [ { _id: 1,
-   name: 'mongo-prod-0.mongodb.mongo.svc.cluster.local:27017',
+   name: 'mongo-prod-0.mongodb.db-namespace.svc.cluster.local:27017',
    stateStr: 'PRIMARY',
    ...},
  { _id: 2,
-   name: 'mongo-prod-1.mongodb.mongo.svc.cluster.local:27017',
+   name: 'mongo-prod-1.mongodb.db-namespace.svc.cluster.local:27017',
    stateStr: 'SECONDARY',
    ...},
  { _id: 2,
-   name: 'mongo-prod-2.mongodb.mongo.svc.cluster.local:27017',
+   name: 'mongo-prod-2.mongodb.db-namespace.svc.cluster.local:27017',
    stateStr: 'SECONDARY',
    ...} ]
 ```
 StatefulSet name: `mongo-prod`.  
 Headless service name: `mongodb`.  
-Namespace: `mongo`.
+Namespace: `db-namespace`.
 
-Read more about the stable network ids 
+Read more about the stable network IDs
 <a href="https://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/#stable-network-id">here</a>.
 
 An example for a stable network pod ID looks like this:
@@ -91,7 +91,7 @@ Finally if you have a preconfigured replica set you have to make sure that:
 Example of acceptable names:
 ```
 10.48.0.72:27017
-mongo-prod-0.mongodb.mongo.svc.cluster.local:27017
+mongo-prod-0.mongodb.db-namespace.svc.cluster.local:27017
 ```
 Example of not-acceptable names:
 ```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ There you will also find some helper scripts to test out creating the replica se
   Required: NO  
   Default: cluster.local  
   This allows the specification of custom cluster domains. Used for the stable network ID of the k8s Mongo pods. Example for
-  a different could be: "kube.local".   
+  a different domain name could be: "kube.local".   
 
 In its default configuration the sidecar uses the pods' IPs for MongodDB replica names. An example follows:
 ```

--- a/README.md
+++ b/README.md
@@ -29,6 +29,64 @@ There you will also find some helper scripts to test out creating the replica se
   Required: NO  
   Default: 15  
   This is how many seconds a replica set member has to get healthy before automatically being removed from the replica set.
+- KUBERNETES_MONGO_SERVICE_NAME  
+  Required: NO  
+  This should point to the MongoDB Kubernetes service that identifies all the pods. It is used for setting up the DNS
+  configuration when applying this to stateful sets.  
+
+### Note about a preconfigured cluster.
+
+In its default configuration the sidecar uses the pods' IPs for MongodDB replica names. An example follows:
+```
+[ { _id: 1,
+   name: '10.48.0.70:27017',
+   stateStr: 'PRIMARY',
+   ...},
+ { _id: 2,
+   name: '10.48.0.72:27017',
+   stateStr: 'SECONDARY',
+   ...},
+ { _id: 3,
+   name: '10.48.0.73:27017',
+   stateStr: 'SECONDARY',
+   ...} ]
+```
+`Note` that if you have already configured replica set, having different names (than the pod IPs) could lead to duplicates
+for the same pod. This is not good, since Mongo cannot deal well with duplicates and may break the whole replica set and
+leave it in a non-working state! Before moving to the sidecar, make sure you use the IPs for names of the pods. Always make
+sure to test it before applying it on production.
+
+If you want to use the StatefulSets' stable network IDs, you have to make sure that you use the `KUBERNETES_MONGO_SERVICE_NAME`
+environmental variable. Then the MongoDB replica set node names could look like this:
+```
+[ { _id: 1,
+   name: 'mongo-prod-0.mongodb.mongon.svc.cluster.local:27017',
+   stateStr: 'PRIMARY',
+   ...},
+ { _id: 2,
+   name: 'mongo-prod-1.mongodb.mongon.svc.cluster.local:27017',
+   stateStr: 'SECONDARY',
+   ...},
+ { _id: 2,
+   name: 'mongo-prod-2.mongodb.mongon.svc.cluster.local:27017',
+   stateStr: 'SECONDARY',
+   ...} ]
+```
+StatefulSet name: `mongo-prod`.  
+Headless service name: `mongodb`.  
+Namespace: `mongons`.
+
+Read more about the stable network ids 
+<a href="https://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/#stable-network-id">here</a>.
+
+An example of the DNS name of a pod, using those stable network IDs looks like this:
+`$(statefulset name)-$(ordinal).$(service name).$(namespace).svc.cluster.local`.
+The stateful set name + the ordinal form the pod name, the service name is passed via `KUBERNETES_MONGO_SERVICE_NAME`,
+the namespace is extracted from the pod metadata and the rest is static.
+
+Another thing to consider when running a cluster with the mongo-k8s-sidecar, it will prefer the stateful set stable
+network ID over the pod IP. Also if you have pods already having the IP as identifier, it should not add an additional
+entry for it, using the stable network ID, it should only add it for new entries in the cluster.
 
 ## Debugging
 

--- a/README.md
+++ b/README.md
@@ -29,12 +29,19 @@ There you will also find some helper scripts to test out creating the replica se
   Required: NO  
   Default: 15  
   This is how many seconds a replica set member has to get healthy before automatically being removed from the replica set.
+- MONGO_PORT
+  Required: NO
+  Default: 27017
+  Configures the mongo port, allows the usage non-standard ports.
 - KUBERNETES_MONGO_SERVICE_NAME  
   Required: NO  
   This should point to the MongoDB Kubernetes service that identifies all the pods. It is used for setting up the DNS
   configuration when applying this to stateful sets.  
-
-### Note about a preconfigured cluster.
+- KUBERNETES_CLUSTER_DOMAIN  
+  Required: NO  
+  Default: cluster.local  
+  This allows the specification of custom cluster domains. Used for the stable network ID of the k8s Mongo pods. Example for
+  a different could be: "kube.local".   
 
 In its default configuration the sidecar uses the pods' IPs for MongodDB replica names. An example follows:
 ```

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -19,12 +19,53 @@ var getMongoPodLabelCollection = function() {
   return labels;
 };
 
-var getKubernetesROServiceAddress = function() {
-  return process.env.KUBERNETES_SERVICE_HOST + ":" + process.env.KUBERNETES_SERVICE_PORT
+var getk8sROServiceAddress = function() {
+	return process.env.KUBERNETES_SERVICE_HOST + ":" + process.env.KUBERNETES_SERVICE_PORT
 };
 
+/**
+ * @returns k8sClusterDomain should the name of the kubernetes domain where the cluster is running. Can be convigured via the environmental
+ * variable 'KUBERNETES_CLUSTER_DOMAIN'.
+ */
+var getK8sClusterDomain = function() {
+  var domain = process.env.KUBERNETES_CLUSTER_DOMAIN || "cluster.local";
+  verifyCorrectnessOfDomain(domain);
+  return domain;
+
+  /**
+   * Calls a reverse DNS lookup to ensure that the given custom domain name matches the actual one. Raises a console warning if that is not
+   * the case.
+   * @param clusterDomain the domain to verify.
+   */
+  function verifyCorrectnessOfDomain(clusterDomain) {
+	var dns = require('dns');
+    if(clusterDomain && (!dns.getServers() || dns.getServers().length > 0)) {
+      // In the case that we can resolve the DNS servers, we get the first and try to retrieve its host.
+      dns.reverse(dns.getServers()[0], function(err, host) {
+        if(host.length < 1 || !host[0].endsWith(clusterDomain)) {
+          console.warn("Possibly wrong cluster domain name! Detected '" + clusterDomain + "' but expected similar to: ", host)
+        } else {
+          console.info("The cluster domain '" + clusterDomain + "' was successfully verified.")
+        }
+      });
+    }
+  }
+};
+
+/**
+ * @returns k8sMongoServiceName should be the name of the (headless) k8s service operating the mongo pods.
+ */
 var getK8sMongoServiceName = function() {
 	return process.env.KUBERNETES_MONGO_SERVICE_NAME || false;
+};
+
+/**
+ * @returns mongoPort this is the port on which the mongo instances run. Default is 27017.
+ */
+var getMongoDbPort = function() {
+  var mongoPort = process.env.MONGO_PORT || 27017;
+  console.info("Using mongo port: ", mongoPort);
+  return mongoPort;
 };
 
 module.exports = {
@@ -34,6 +75,8 @@ module.exports = {
   env: process.env.NODE_ENV || 'local',
   mongoPodLabels: getMongoPodLabels(),
   mongoPodLabelCollection: getMongoPodLabelCollection(),
-  kubernetesROServiceAddress: getKubernetesROServiceAddress(),
-  k8sMongoServiceName: getK8sMongoServiceName()
+  k8sROServiceAddress: getk8sROServiceAddress(),
+  k8sMongoServiceName: getK8sMongoServiceName(),
+  k8sClusterDomain: getK8sClusterDomain(),
+  mongoPort: getMongoDbPort()
 };

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -23,6 +23,10 @@ var getKubernetesROServiceAddress = function() {
   return process.env.KUBERNETES_SERVICE_HOST + ":" + process.env.KUBERNETES_SERVICE_PORT
 };
 
+var getK8sMongoServiceName = function() {
+	return process.env.KUBERNETES_MONGO_SERVICE_NAME || false;
+};
+
 module.exports = {
   namespace: process.env.KUBE_NAMESPACE,
   loopSleepSeconds: process.env.MONGO_SIDECAR_SLEEP_SECONDS || 5,
@@ -30,5 +34,6 @@ module.exports = {
   env: process.env.NODE_ENV || 'local',
   mongoPodLabels: getMongoPodLabels(),
   mongoPodLabelCollection: getMongoPodLabelCollection(),
-  kubernetesROServiceAddress: getKubernetesROServiceAddress()
+  kubernetesROServiceAddress: getKubernetesROServiceAddress(),
+  k8sMongoServiceName: getK8sMongoServiceName()
 };

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -20,12 +20,12 @@ var getMongoPodLabelCollection = function() {
 };
 
 var getk8sROServiceAddress = function() {
-	return process.env.KUBERNETES_SERVICE_HOST + ":" + process.env.KUBERNETES_SERVICE_PORT
+  return process.env.KUBERNETES_SERVICE_HOST + ":" + process.env.KUBERNETES_SERVICE_PORT
 };
 
 /**
- * @returns k8sClusterDomain should the name of the kubernetes domain where the cluster is running. Can be convigured via the environmental
- * variable 'KUBERNETES_CLUSTER_DOMAIN'.
+ * @returns k8sClusterDomain should the name of the kubernetes domain where the cluster is running.
+ * Can be convigured via the environmental variable 'KUBERNETES_CLUSTER_DOMAIN'.
  */
 var getK8sClusterDomain = function() {
   var domain = process.env.KUBERNETES_CLUSTER_DOMAIN || "cluster.local";
@@ -33,19 +33,19 @@ var getK8sClusterDomain = function() {
   return domain;
 
   /**
-   * Calls a reverse DNS lookup to ensure that the given custom domain name matches the actual one. Raises a console warning if that is not
-   * the case.
+   * Calls a reverse DNS lookup to ensure that the given custom domain name matches the actual one.
+   * Raises a console warning if that is not the case.
    * @param clusterDomain the domain to verify.
    */
   function verifyCorrectnessOfDomain(clusterDomain) {
-	var dns = require('dns');
-    if(clusterDomain && (!dns.getServers() || dns.getServers().length > 0)) {
+    var dns = require('dns');
+    if(clusterDomain && dns.getServers() && dns.getServers().length > 0) {
       // In the case that we can resolve the DNS servers, we get the first and try to retrieve its host.
       dns.reverse(dns.getServers()[0], function(err, host) {
-        if(host.length < 1 || !host[0].endsWith(clusterDomain)) {
-          console.warn("Possibly wrong cluster domain name! Detected '" + clusterDomain + "' but expected similar to: ", host)
+        if(err || host.length < 1 || !host[0].endsWith(clusterDomain)) {
+          console.warn("Possibly wrong cluster domain name! Detected '%s' but expected similar to: %s",  clusterDomain, host);
         } else {
-          console.info("The cluster domain '" + clusterDomain + "' was successfully verified.")
+          console.log("The cluster domain '%s' was successfully verified.", clusterDomain)
         }
       });
     }
@@ -56,7 +56,7 @@ var getK8sClusterDomain = function() {
  * @returns k8sMongoServiceName should be the name of the (headless) k8s service operating the mongo pods.
  */
 var getK8sMongoServiceName = function() {
-	return process.env.KUBERNETES_MONGO_SERVICE_NAME || false;
+  return process.env.KUBERNETES_MONGO_SERVICE_NAME || false;
 };
 
 /**
@@ -64,7 +64,7 @@ var getK8sMongoServiceName = function() {
  */
 var getMongoDbPort = function() {
   var mongoPort = process.env.MONGO_PORT || 27017;
-  console.info("Using mongo port: ", mongoPort);
+  console.log("Using mongo port: %s", mongoPort);
   return mongoPort;
 };
 

--- a/src/lib/k8s.js
+++ b/src/lib/k8s.js
@@ -7,8 +7,8 @@ fs = require('fs');
 var readToken = fs.readFileSync('/var/run/secrets/kubernetes.io/serviceaccount/token');
 
 var client = new Client({
-  host: config.kubernetesROServiceAddress,
-  namespace: config.namespace, 
+  host: config.k8sROServiceAddress,
+  namespace: config.namespace,
   protocol: 'https',
   version: 'v1',
   token: readToken

--- a/src/lib/mongo.js
+++ b/src/lib/mongo.js
@@ -1,6 +1,7 @@
 var Db = require('mongodb').Db;
 var MongoServer = require('mongodb').Server;
 var async = require('async');
+var config = require('./config');
 
 var localhost = '127.0.0.1'; //Can access mongo as localhost from a sidecar
 
@@ -17,7 +18,7 @@ var getDb = function(host, done) {
   }
 
   host = host || localhost;
-  var mongoDb = new Db('local', new MongoServer(host, 27017));
+  var mongoDb = new Db('local', new MongoServer(host, config.mongoPort));
   mongoDb.open(function (err, db) {
     if (err) {
       return done(err);

--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -187,7 +187,11 @@ var notInReplicaSet = function(db, pods, done) {
 
     if (podElection(pods)) {
       console.log('Pod has been elected for replica set initialization');
-      mongo.initReplSet(db, hostIpAndPort, done);
+      var primary = pods[0]; // After the sort election, the 0-th pod should be the primary.
+      var primaryStableNetworkAddressAndPort = getPodStableNetworkAddressAndPort(primary);
+      // Prefer the stable network ID over the pod IP, if present.
+      var primaryAddressAndPort = primaryStableNetworkAddressAndPort ? primaryStableNetworkAddressAndPort : hostIpAndPort;
+      mongo.initReplSet(db, primaryAddressAndPort, done);
       return;
     }
 
@@ -229,22 +233,55 @@ var addrToAddLoop = function(pods, members) {
       continue;
     }
 
-    var podIp = pod.status.podIP;
-    var podAddr = podIp  + ':27017';
+    var podIpAddr = getPodIpAddressAndPort(pod);
+    var podStableNetworkAdd = getPodStableNetworkAddressAndPort(pod);
     var podInRs = false;
+
     for (var j in members) {
       var member = members[j];
-      if (member.name === podAddr) {
+      if ((podIpAddr && member.name === podIpAddr) || (podStableNetworkAdd && member.name === podStableNetworkAdd)) {
+        /* If we have the pod's ip or the stable network address already in the config, no need to read it. Checks both the pod IP and the
+        * stable network ID - we don't want any duplicates - either one of the two is sufficient to consider the node present. */
         podInRs = true;
         continue;
       }
     }
 
     if (!podInRs) {
-      addrToAdd.push(podAddr);
+      // If the node was not present, we prefer the stable network ID, if present.
+      var addrToUse = podStableNetworkAdd ? podStableNetworkAdd : podIpAddr;
+      addrToAdd.push(addrToUse);
     }
   }
   return addrToAdd;
+};
+
+/**
+ * @param pod the Kubernetes pod, containing the info.
+ * @returns podIp the pod's IP address with the default port of 27017 attached at the end. Example WWW.XXX.YYY.ZZZ:27017. It returns undefined,
+ * if the data is insufficient to retrieve the IP address.
+ */
+var getPodIpAddressAndPort = function(pod) {
+  var podIpAddress = undefined;
+  if (pod && pod.status && pod.status.podIP) {
+    podIpAddress = pod.status.podIP + ":27017";
+  }
+  return podIpAddress;
+};
+
+/**
+ * Gets the pod's address. It can be either in the form of '<pod-name>.<mongo-kubernetes-service>.<pod-namespace>.svc.cluster.local:27017'.
+ * See: <a href="https://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/#stable-network-id">Stateful Set documentation</a>
+ * for more details. If those are not set, then simply the pod's IP is returned.
+ * @param pod the Kubernetes pod, containing the information from the k8s client.
+ * @returns stableNetworkAddress the k8s MongoDB stable network address, or undefined.
+ */
+var getPodStableNetworkAddressAndPort = function(pod) {
+  var podStableNetworkAddress = undefined;
+  if (config.k8sMongoServiceName && pod && pod.metadata && pod.metadata.name && pod.metadata.namespace) {
+    podStableNetworkAddress =  pod.metadata.name + "." + config.k8sMongoServiceName + "." + pod.metadata.namespace + ".svc.cluster.local:27017";
+  }
+  return podStableNetworkAddress;
 };
 
 module.exports = {

--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -22,7 +22,7 @@ var init = function(done) {
     }
 
     hostIp = addr;
-    hostIpAndPort = hostIp + ':27017';
+    hostIpAndPort = hostIp + ':' + config.mongoPort;
 
     done();
   });
@@ -258,20 +258,21 @@ var addrToAddLoop = function(pods, members) {
 
 /**
  * @param pod this is the Kubernetes pod, containing the info.
- * @returns podIp the pod's IP address with the default port of 27017 attached at the end. Example WWW.XXX.YYY.ZZZ:27017. It returns undefined,
- * if the data is insufficient to retrieve the IP address.
+ * @returns podIp the pod's IP address with the default port of 27017 (retrieved from the config) attached at the end. Example
+ * WWW.XXX.YYY.ZZZ:27017. It returns undefined, if the data is insufficient to retrieve the IP address.
  */
 var getPodIpAddressAndPort = function(pod) {
   var podIpAddress = undefined;
   if (pod && pod.status && pod.status.podIP) {
-    podIpAddress = pod.status.podIP + ":27017";
+    podIpAddress = pod.status.podIP + ":" + config.mongoPort;
   }
   return podIpAddress;
 };
 
 /**
- * Gets the pod's address. It can be either in the form of '<pod-name>.<mongo-kubernetes-service>.<pod-namespace>.svc.cluster.local:27017'.
- * See: <a href="https://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/#stable-network-id">Stateful Set documentation</a>
+ * Gets the pod's address. It can be either in the form of
+ * '<pod-name>.<mongo-kubernetes-service>.<pod-namespace>.svc.cluster.local:<mongo-port>'. See:
+ * <a href="https://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/#stable-network-id">Stateful Set documentation</a>
  * for more details. If those are not set, then simply the pod's IP is returned.
  * @param pod the Kubernetes pod, containing the information from the k8s client.
  * @returns stableNetworkAddress the k8s MongoDB stable network address, or undefined.
@@ -279,7 +280,10 @@ var getPodIpAddressAndPort = function(pod) {
 var getPodStableNetworkAddressAndPort = function(pod) {
   var podStableNetworkAddress = undefined;
   if (config.k8sMongoServiceName && pod && pod.metadata && pod.metadata.name && pod.metadata.namespace) {
-    podStableNetworkAddress =  pod.metadata.name + "." + config.k8sMongoServiceName + "." + pod.metadata.namespace + ".svc.cluster.local:27017";
+    var clusterDomain = config.k8sClusterDomain;
+    var mongoPort = config.mongoPort;
+    podStableNetworkAddress = pod.metadata.name + "." + config.k8sMongoServiceName + "." + pod.metadata.namespace + ".svc." +
+      clusterDomain + ":" + mongoPort;
   }
   return podStableNetworkAddress;
 };

--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -257,7 +257,7 @@ var addrToAddLoop = function(pods, members) {
 };
 
 /**
- * @param pod the Kubernetes pod, containing the info.
+ * @param pod this is the Kubernetes pod, containing the info.
  * @returns podIp the pod's IP address with the default port of 27017 attached at the end. Example WWW.XXX.YYY.ZZZ:27017. It returns undefined,
  * if the data is insufficient to retrieve the IP address.
  */


### PR DESCRIPTION
Adds the possiblity to use the stable network ID, introduced with the
StatefulSets. 
This change adds several new environmental variables:
- MONGO_PORT allows the customization of the mongo port, default
is still 27017
- KUBERNETES_MONGO_SERVICE_NAME defines a mongo (possibly
headless) k8s service, that points to all the mongo pods. Used for the 
generation of a stable network ID. This property only is enough to enable
the stable network ID.
- KUBERNETES_CLUSTER_DOMAIN allows the specification of a
custom cluster domain name, used for the stable network ID generation.

A stable network id could look like this:
`$(pod-name).$(service-name).$(namespace).svc.cluster.local`.

Also extends the README for the new use cases.