### PR TITLE
Environment var for config server replica set

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ There you will also find some helper scripts to test out creating the replica se
   Required: NO
   Default: 27017
   Configures the mongo port, allows the usage of non-standard ports.  
+- CONFIG_SVR
+  Required: NO
+  Default: false
+  Configures the [configsvr](https://docs.mongodb.com/manual/reference/replica-configuration/#rsconf.configsvr) variable when initializing the replicaset.
 - KUBERNETES_MONGO_SERVICE_NAME  
   Required: NO  
   This should point to the MongoDB Kubernetes (headless) service that identifies all the pods. It is used for setting up the

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -81,6 +81,17 @@ var getMongoDbPort = function() {
   return mongoPort;
 };
 
+/**
+ *  @returns boolean to define the RS as a configsvr or not. Default is false
+ */
+var isConfigRS = function() {
+  var configsvr = process.env.CONFIG_SVR || false;
+  if (configsvr) {
+    console.log("ReplicaSet is configured as a configsvr");
+  }
+  return !!configsvr;
+};
+
 module.exports = {
   namespace: process.env.KUBE_NAMESPACE,
   loopSleepSeconds: process.env.MONGO_SIDECAR_SLEEP_SECONDS || 5,
@@ -91,5 +102,6 @@ module.exports = {
   k8sROServiceAddress: getk8sROServiceAddress(),
   k8sMongoServiceName: getK8sMongoServiceName(),
   k8sClusterDomain: getK8sClusterDomain(),
-  mongoPort: getMongoDbPort()
+  mongoPort: getMongoDbPort(),
+  isConfigRS: isConfigRS(),
 };

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -85,7 +85,7 @@ var getMongoDbPort = function() {
  *  @returns boolean to define the RS as a configsvr or not. Default is false
  */
 var isConfigRS = function() {
-  var configsvr = process.env.CONFIG_SVR || false;
+  var configsvr = /^(?:y|yes|true|1)$/i.test((process.env.CONFIG_SVR || '').trim());
   if (configsvr) {
     console.log("ReplicaSet is configured as a configsvr");
   }

--- a/src/lib/mongo.js
+++ b/src/lib/mongo.js
@@ -51,6 +51,9 @@ var replSetGetStatus = function(db, done) {
 var initReplSet = function(db, hostIpAndPort, done) {
   console.log('initReplSet', hostIpAndPort);
 
+  var _defaultConf = {
+    configsvr: config.isConfigRS
+  };
   db.admin().command({ replSetInitiate: {} }, {}, function (err) {
     if (err) {
       return done(err);
@@ -62,6 +65,8 @@ var initReplSet = function(db, hostIpAndPort, done) {
         return done(err);
       }
 
+      console.log('initial config is', config);
+      config.configsvr = _defaultConf.configsvr;
       config.members[0].host = hostIpAndPort;
       async.retry({times: 20, interval: 500}, function(callback) {
         replSetReconfig(db, config, false, callback);

--- a/src/lib/mongo.js
+++ b/src/lib/mongo.js
@@ -63,7 +63,7 @@ var initReplSet = function(db, hostIpAndPort, done) {
       }
 
       console.log('initial rsConfig is', rsConfig);
-      rsConfig.configsvr = config.configsvr;
+      rsConfig.configsvr = config.isConfigRS;
       rsConfig.members[0].host = hostIpAndPort;
       async.retry({times: 20, interval: 500}, function(callback) {
         replSetReconfig(db, rsConfig, false, callback);


### PR DESCRIPTION
See here, a feature with according documentation and code to enable launch of config replicaset.

The feature is pretty straightforward, if `CONFIG_SVR` env variable is set (whatever value) it will resolve to `true` when initialising the replicaset.

The only thing that bothered me is that you're using `config` as a global variable and also as a function parameter, hence a choice had to me made, but that can be changed if you'd like to...

Don't hesitate to make any comments on this.