### PR TITLE
Add support for configuring pods as arbiterOnly based on labels

### DIFF
--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -4,12 +4,23 @@ var getMongoPodLabels = function() {
   return process.env.MONGO_SIDECAR_POD_LABELS || false;
 };
 
+var getMongoPodLabelsArbiter = function() {
+  return process.env.MONGO_SIDECAR_POD_LABELS_ARBITER || false;
+};
+
 var getMongoPodLabelCollection = function() {
-  var podLabels = getMongoPodLabels();
-  if (!podLabels) {
+  return parseLabelCollection(getMongoPodLabels());
+};
+
+var getMongoPodLabelCollectionArbiter = function() {
+  return parseLabelCollection(getMongoPodLabelsArbiter());
+};
+
+var parseLabelCollection = function(labelString) {
+  if (!labelString) {
     return false;
   }
-  var labels = process.env.MONGO_SIDECAR_POD_LABELS.split(',');
+  var labels = labelString.split(',');
   for (var i in labels) {
     var keyAndValue = labels[i].split('=');
     labels[i] = {
@@ -103,6 +114,8 @@ module.exports = {
   unhealthySeconds: process.env.MONGO_SIDECAR_UNHEALTHY_SECONDS || 15,
   env: process.env.NODE_ENV || 'local',
   mongoPodLabels: getMongoPodLabels(),
+  mongoPodLabelsArbiter: getMongoPodLabelsArbiter(),
+  mongoPodLabelCollectionArbiter: getMongoPodLabelCollectionArbiter(),
   mongoPodLabelCollection: getMongoPodLabelCollection(),
   k8sROServiceAddress: getk8sROServiceAddress(),
   k8sMongoServiceName: getK8sMongoServiceName(),

--- a/src/lib/k8s.js
+++ b/src/lib/k8s.js
@@ -50,5 +50,6 @@ var podContainsLabels = function podContainsLabels(pod, labels) {
 };
 
 module.exports = {
-  getMongoPods: getMongoPods
+  getMongoPods: getMongoPods,
+  podContainsLabels: podContainsLabels
 };

--- a/src/lib/mongo.js
+++ b/src/lib/mongo.js
@@ -2,6 +2,7 @@ var Db = require('mongodb').Db;
 var MongoServer = require('mongodb').Server;
 var async = require('async');
 var config = require('./config');
+var k8s = require('./k8s');
 
 var localhost = '127.0.0.1'; //Can access mongo as localhost from a sidecar
 
@@ -132,8 +133,13 @@ var addNewMembers = function(rsConfig, addrsToAdd) {
   for (var i in addrsToAdd) {
     var cfg = {
       _id: ++max,
-      host: addrsToAdd[i]
+      host: addrsToAdd[i].host
     };
+
+    // check if we want to add the pod as an arbiter only based on its labels
+    if (k8s.podContainsLabels(addrsToAdd[i].pod, config.mongoPodLabelCollectionArbiter)) {
+      cfg.arbiterOnly = true;
+    }
 
     rsConfig.members.push(cfg);
   }

--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -213,7 +213,9 @@ var invalidReplicaSet = function(db, pods, done) {
 var podElection = function(pods) {
   //Because all the pods are going to be running this code independently, we need a way to consistently find the same
   //node to kick things off, the easiest way to do that is convert their ips into longs and find the highest
-  pods.sort(function(a,b) {
+  pods
+  .filter(function(pod) { return !k8s.podContainsLabels(pod, config.mongoPodLabelCollectionArbiter); })
+  .sort(function(a,b) {
     var aIpVal = ip.toLong(a.status.podIP);
     var bIpVal = ip.toLong(b.status.podIP);
     if (aIpVal < bIpVal) return -1;
@@ -250,7 +252,8 @@ var addrToAddLoop = function(pods, members) {
     if (!podInRs) {
       // If the node was not present, we prefer the stable network ID, if present.
       var addrToUse = podStableNetworkAddr || podIpAddr;
-      addrToAdd.push(addrToUse);
+      var obj = { host: addrToUse, pod: pod };
+      addrToAdd.push(obj);
     }
   }
   return addrToAdd;


### PR DESCRIPTION
Still needs documentation for the new env variable MONGO_SIDECAR_POD_LABELS_ARBITER. This is something we needed in our cluster, maybe it is also of interest to others. What do you think about the approach of additional labels used for selecting a subset of the pods?