### PR TITLE
Support mongodb 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ Command
             - mongod
             - "--replSet"
             - heroku
+            - "--bind_ip"
+            - 0.0.0.0
             - "--smallfiles"
             - "--noprealloc"
             - "--sslMode"

--- a/example/StatefulSet/mongo-statefulset.yaml
+++ b/example/StatefulSet/mongo-statefulset.yaml
@@ -46,6 +46,8 @@ spec:
             - mongod
             - "--replSet"
             - rs0
+            - "--bind_ip"
+            - 0.0.0.0
             - "--smallfiles"
             - "--noprealloc"
           ports:

--- a/example/ceph_rbd_pod_examples/README.md
+++ b/example/ceph_rbd_pod_examples/README.md
@@ -46,6 +46,8 @@ spec:
             - mongod
             - "--replSet"
             - rs0
+            - "--bind_ip"
+            - 0.0.0.0
             - "--smallfiles"
             - "--noprealloc"
           ports:

--- a/example/ceph_rbd_pod_examples/mongo-rc-rbd-1.yaml
+++ b/example/ceph_rbd_pod_examples/mongo-rc-rbd-1.yaml
@@ -29,6 +29,8 @@ spec:
             - mongod
             - "--replSet"
             - rs0
+            - "--bind_ip"
+            - 0.0.0.0
             - "--smallfiles"
             - "--noprealloc"
           ports:

--- a/example/ceph_rbd_pod_examples/mongo-rc-rbd-2.yaml
+++ b/example/ceph_rbd_pod_examples/mongo-rc-rbd-2.yaml
@@ -29,6 +29,8 @@ spec:
             - mongod
             - "--replSet"
             - rs0
+            - "--bind_ip"
+            - 0.0.0.0
             - "--smallfiles"
             - "--noprealloc"
           ports:

--- a/example/ceph_rbd_pod_examples/mongo-rc-rbd-3.yaml
+++ b/example/ceph_rbd_pod_examples/mongo-rc-rbd-3.yaml
@@ -29,6 +29,8 @@ spec:
             - mongod
             - "--replSet"
             - rs0
+            - "--bind_ip"
+            - 0.0.0.0
             - "--smallfiles"
             - "--noprealloc"
           ports:

--- a/example/emptydir_pod_examples/mongo-rc-emptydir-1.yaml
+++ b/example/emptydir_pod_examples/mongo-rc-emptydir-1.yaml
@@ -29,6 +29,8 @@ spec:
             - mongod
             - "--replSet"
             - rs0
+            - "--bind_ip"
+            - 0.0.0.0
             - "--smallfiles"
             - "--noprealloc"
           ports:

--- a/example/emptydir_pod_examples/mongo-rc-emptydir-2.yaml
+++ b/example/emptydir_pod_examples/mongo-rc-emptydir-2.yaml
@@ -29,6 +29,8 @@ spec:
             - mongod
             - "--replSet"
             - rs0
+            - "--bind_ip"
+            - 0.0.0.0
             - "--smallfiles"
             - "--noprealloc"
           ports:

--- a/example/emptydir_pod_examples/mongo-rc-emptydir-3.yaml
+++ b/example/emptydir_pod_examples/mongo-rc-emptydir-3.yaml
@@ -29,6 +29,8 @@ spec:
             - mongod
             - "--replSet"
             - rs0
+            - "--bind_ip"
+            - 0.0.0.0
             - "--smallfiles"
             - "--noprealloc"
           ports:

--- a/example/emptydir_pod_examples/mongo-rc-emptydir-4.yaml
+++ b/example/emptydir_pod_examples/mongo-rc-emptydir-4.yaml
@@ -29,6 +29,8 @@ spec:
             - mongod
             - "--replSet"
             - rs0
+            - "--bind_ip"
+            - 0.0.0.0
             - "--smallfiles"
             - "--noprealloc"
           ports:

--- a/example/mongo-controller-flocker-template.yaml
+++ b/example/mongo-controller-flocker-template.yaml
@@ -29,6 +29,8 @@ spec:
             - mongod
             - "--replSet"
             - rs0
+            - "--bind_ip"
+            - 0.0.0.0
             - "--smallfiles"
             - "--noprealloc"
           ports:

--- a/example/mongo-controller-template.yaml
+++ b/example/mongo-controller-template.yaml
@@ -29,6 +29,8 @@ spec:
             - mongod
             - "--replSet"
             - rs0
+            - "--bind_ip"
+            - 0.0.0.0
             - "--smallfiles"
             - "--noprealloc"
           ports:


### PR DESCRIPTION
MongoDB 3.6 is to bind to localhost 127.0.0.1 by default. It cannot accept the connection from the mongo-sidecar container. 

Thanks @joshorig to point out #68