### PR TITLE
Adding role for RBAC

### DIFF
--- a/example/StatefulSet/README.md
+++ b/example/StatefulSet/README.md
@@ -93,3 +93,10 @@ Put these in your connection url. For example:
 ```
 mongodb://mongo-0.mongo,mongo-1.mongo,mongo-2.mongo:27017/dbname_?'
 ```
+
+## RBAC Role
+If you are running Kubernetes using RBAC, you will likely need to create a role with permission to list pods. The _role.yaml_ file contains an example role and binding which grants the necessary permissions to the default service account in the "mongo" namespace. Update as needed for your environment.
+
+```
+kubectl apply -f role.yaml
+```

--- a/example/StatefulSet/role.yaml
+++ b/example/StatefulSet/role.yaml
@@ -1,0 +1,23 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: mongo
+  name: mongo-pod-read
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mongo-pod-read
+  namespace: mongo
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: mongo
+roleRef:
+  kind: Role
+  name: mongo-pod-read
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This PR adds a role config file which will create a Kubernetes Role and RoleBinding which allows the default ServiceAccount to list pods in the specified namespace. Also added a note to the README.