### PR TITLE
Fix a bug when vm hosting master mongodb is down

### DIFF
--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -232,7 +232,7 @@ var addrToAddLoop = function(pods, members) {
   var addrToAdd = [];
   for (var i in pods) {
     var pod = pods[i];
-    if (pod.status.phase !== 'Running') {
+    if (pod.status.phase !== 'Running' || pod.status.reason === 'NodeLost') {
       continue;
     }
 


### PR DESCRIPTION
Pod mongodb-0 (master) was on node master1. After master1 was shut down, mongodb-0's STATUS was in "Unknown", whereas pod.status.phase was "Running". mongodb-0 is repetitively selected as the cluster's master and removed from cluster as it is not reachable. It inhibited other cluster members to become a master. Sidecar needs to check correct field for pod status.
----logs---
$ kubectl logs -n=maglev-system mongodb-2 -c mongo-sidecar
...
 Pod has been elected as a secondary to do primary work
 Addresses to add:     [ 'mongodb-0.mongodb.svc.cluster.local:27017' ]
...

$ kubectl get po mongodb-0 -n=maglev-system
NAME        READY     STATUS    RESTARTS   AGE
mongodb-0   3/3       Unknown   0          20h
$ kubectl get po mongodb-0 -n=maglev-system -oyaml | grep phase
  phase: Running