### PR TITLE
Add bind_ip_all argument for mongo arguments

### DIFF
--- a/example/StatefulSet/mongo-statefulset.yaml
+++ b/example/StatefulSet/mongo-statefulset.yaml
@@ -50,6 +50,7 @@ spec:
             - 0.0.0.0
             - "--smallfiles"
             - "--noprealloc"
+            - "--bind_ip_all"
           ports:
             - containerPort: 27017
           volumeMounts:


### PR DESCRIPTION
As newer versions of mongod only listen on localhost by default, adding command to listen on all interfaces, as this was blocking the replicaset from forming.