### PR TITLE
Force mongo version to stay compatible with sidecar nodejs driver

### DIFF
--- a/example/StatefulSet/mongo-statefulset.yaml
+++ b/example/StatefulSet/mongo-statefulset.yaml
@@ -41,7 +41,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
         - name: mongo
-          image: mongo
+          image: mongo:3.4
           command:
             - mongod
             - "--replSet"


### PR DESCRIPTION
Spent 2 hours debugging trying to figure out why the sidecar was having connection errors when setting up the replica set. Finally, I figure out that the 2.2 driver used in the nodejs app is not compatible with mongo 4. The mongo version has to be specified in the kubernetes file (stateful example) or the nodejs driver has to be upgraded to 3.1. For now, I elected to change the example. 

See  https://docs.mongodb.com/ecosystem/drivers/driver-compatibility-reference/